### PR TITLE
Add per-game virtual desktop resolution configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 Config.xcconfig
+.DS_Store
+xcuserdata/

--- a/Procyon/Components/GameOptionsView.swift
+++ b/Procyon/Components/GameOptionsView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct GameOptionsView: View {
     @Binding var game: Game?
     @EnvironmentObject var gameOptions: GameOptions
+    @EnvironmentObject var appGlobals: AppGlobals
     
     var preferredMaxFrameRate: String {
         $gameOptions.dxmtPreferredMaxFrameRate.wrappedValue < 20.0 ? "Disabled" : "\($gameOptions.dxmtPreferredMaxFrameRate.wrappedValue)"
@@ -90,6 +91,23 @@ struct GameOptionsView: View {
                             }
                         }
                     }
+                    if(!game!.isNative) {
+                        Divider()
+                        Section("Resolution (Virtual Desktop)") {
+                            Toggle("Enable Virtual Desktop", isOn: $gameOptions.virtualDesktopEnabled)
+                            if(gameOptions.virtualDesktopEnabled) {
+                                TextField("Resolution (e.g. 1920x1080)", text: $gameOptions.virtualDesktopResolution)
+                                HStack {
+                                    ForEach(BottleResolutionManager.detectDisplayProfiles(), id: \.id) { profile in
+                                        Button("\(profile.name) (\(profile.resolution))") {
+                                            gameOptions.virtualDesktopResolution = profile.resolution
+                                        }
+                                        .buttonStyle(.bordered)
+                                    }
+                                }
+                            }
+                        }
+                    }
                     HStack {
                         Button("Save settings") {
                             console.log("saving")
@@ -118,14 +136,31 @@ struct GameOptionsView: View {
             if let data: GameOptionsData = readUsrDefData(key: gameOptKey) {
                 self.gameOptions.set(data: data)
             }
+            if(!game!.isNative) {
+                loadResolutionFromBottle()
+            }
         }
     }
+
+    private func loadResolutionFromBottle() {
+        guard !appGlobals.selectedBottle.isEmpty,
+              let bottleURL = URL(string: appGlobals.selectedBottle) else { return }
+        let manager = BottleResolutionManager(bottleURL: bottleURL)
+        do {
+            let state = try manager.loadCurrentState()
+            gameOptions.virtualDesktopEnabled = state.isVirtualDesktopEnabled
+            gameOptions.virtualDesktopResolution = state.resolution
+        } catch {
+            console.error("Failed to load resolution state: \(String(reflecting: error))")
+        }
+    }
+
 }
 
 #Preview {
     @State @Previewable var game: Game? = .mock
     @StateObject @Previewable var gameOptions: GameOptions = GameOptions(cxGraphicsBackend: "dxmt")
-    
-    GameOptionsView(game: $game).environmentObject(gameOptions)
+    @StateObject @Previewable var appGlobals: AppGlobals = AppGlobals()
 
+    GameOptionsView(game: $game).environmentObject(gameOptions).environmentObject(appGlobals)
 }

--- a/Procyon/Types.swift
+++ b/Procyon/Types.swift
@@ -36,7 +36,9 @@ struct GameOptionsData: Codable { // this is used for reading saved properties
     var envVariables: String
     var sdlEnabled: Bool
     var hidrawDisabled: Bool
-    
+    var virtualDesktopEnabled: Bool
+    var virtualDesktopResolution: String
+
     init(data: GameOptions) {
         self.cxGraphicsBackend = data.cxGraphicsBackend
         self.wineMSync = data.wineMSync
@@ -51,6 +53,8 @@ struct GameOptionsData: Codable { // this is used for reading saved properties
         self.envVariables = data.envVariables
         self.sdlEnabled = data.enableSDL
         self.hidrawDisabled = data.disableHidraw
+        self.virtualDesktopEnabled = data.virtualDesktopEnabled
+        self.virtualDesktopResolution = data.virtualDesktopResolution
     }
 }
 
@@ -72,8 +76,10 @@ class GameOptions: ObservableObject { // this is used as form state
     @Published var envVariables: String
     @Published var enableSDL: Bool
     @Published var disableHidraw: Bool
-    
-    init(cxGraphicsBackend: String = "d3dmetal", wineMSync: Bool = true, mtlHudEnabled: Bool = false, x87PatchEnabled: Bool = false, dx9PatchEnabled: Bool = false, dxvk: String? = nil, wineEsync: String? = nil, d3dMEnableMetalFX: String? = nil, d3dSupportDXR: String? = nil, gameArguments: String = "", dxmtPreferredMaxFrameRate: Double = 0, dxmtMetalFXSpatial: Bool = false, dxmtMetalSpatialUpscaleFactor: Double = 1.0, advertiseAVX: Bool = true, envVariables: String = "", sdlEnabled: Bool = true, hidrawDisabled: Bool = false) {
+    @Published var virtualDesktopEnabled: Bool
+    @Published var virtualDesktopResolution: String
+
+    init(cxGraphicsBackend: String = "d3dmetal", wineMSync: Bool = true, mtlHudEnabled: Bool = false, x87PatchEnabled: Bool = false, dx9PatchEnabled: Bool = false, dxvk: String? = nil, wineEsync: String? = nil, d3dMEnableMetalFX: String? = nil, d3dSupportDXR: String? = nil, gameArguments: String = "", dxmtPreferredMaxFrameRate: Double = 0, dxmtMetalFXSpatial: Bool = false, dxmtMetalSpatialUpscaleFactor: Double = 1.0, advertiseAVX: Bool = true, envVariables: String = "", sdlEnabled: Bool = true, hidrawDisabled: Bool = false, virtualDesktopEnabled: Bool = false, virtualDesktopResolution: String = "1920x1080") {
         self.cxGraphicsBackend = cxGraphicsBackend
         self.wineMSync = wineMSync
         self.mtlHudEnabled = mtlHudEnabled
@@ -91,6 +97,8 @@ class GameOptions: ObservableObject { // this is used as form state
         self.envVariables = envVariables
         self.enableSDL = sdlEnabled
         self.disableHidraw = hidrawDisabled
+        self.virtualDesktopEnabled = virtualDesktopEnabled
+        self.virtualDesktopResolution = virtualDesktopResolution
     }
     func set(data: GameOptionsData) {
         self.cxGraphicsBackend = data.cxGraphicsBackend
@@ -106,6 +114,8 @@ class GameOptions: ObservableObject { // this is used as form state
         self.envVariables = data.envVariables
         self.enableSDL = data.sdlEnabled
         self.disableHidraw = data.hidrawDisabled
+        self.virtualDesktopEnabled = data.virtualDesktopEnabled
+        self.virtualDesktopResolution = data.virtualDesktopResolution
     }
 }
 

--- a/Procyon/Util/Launcher.swift
+++ b/Procyon/Util/Launcher.swift
@@ -116,6 +116,23 @@ func launchWindowsGame(id: String, cxAppPath: String, selectedBottle: String, op
         console.error("Missing game options for game with id \(id) - cannot launch (options = nil)")
         return
     }
+
+    // Apply per-game resolution to user.reg (read on next Wine boot)
+    if let bottleURL = URL(string: selectedBottle) {
+        let resManager = BottleResolutionManager(bottleURL: bottleURL)
+        let currentState = try resManager.loadCurrentState()
+        let wantEnabled = options!.virtualDesktopEnabled
+        let wantResolution = options!.virtualDesktopResolution
+
+        let needsChange = currentState.isVirtualDesktopEnabled != wantEnabled ||
+            (wantEnabled && currentState.resolution != wantResolution)
+
+        if needsChange {
+            let resolution = wantEnabled ? wantResolution : nil
+            try resManager.applyResolution(resolution)
+        }
+    }
+
     let f = FileManager.default
 
     var command = ""

--- a/Procyon/Util/Resolution.swift
+++ b/Procyon/Util/Resolution.swift
@@ -1,0 +1,112 @@
+//
+//  Resolution.swift
+//  Procyon
+//
+//  Resolution configuration for CrossOver bottles using Wine registry.
+//  Based on CXRes logic.
+//
+
+import AppKit
+
+struct ResolutionProfile: Codable, Identifiable, Equatable, Hashable {
+    var id = UUID()
+    var name: String
+    var resolution: String
+}
+
+struct ResolutionState {
+    var isVirtualDesktopEnabled: Bool
+    var resolution: String // e.g. "1920x1080"
+    var dpi: UInt32         // e.g. 96
+}
+
+class BottleResolutionManager {
+    private let bottleURL: URL
+    private let registryFile: WineRegistryFile
+
+    private let explorerPath = "Software\\\\Wine\\\\Explorer"
+    private let desktopsPath = "Software\\\\Wine\\\\Explorer\\\\Desktops"
+    private let fontsPath = "Software\\\\Wine\\\\Fonts"
+
+    init(bottleURL: URL) {
+        self.bottleURL = bottleURL
+        let regURL = bottleURL.appendingPathComponent("user.reg")
+        self.registryFile = WineRegistryFile(fileURL: regURL)
+    }
+
+    // MARK: - Read
+
+    func loadCurrentState() throws -> ResolutionState {
+        try registryFile.load()
+
+        let explorerSection = registryFile.section(forPath: explorerPath)
+        let desktopsSection = registryFile.section(forPath: desktopsPath)
+        let fontsSection = registryFile.section(forPath: fontsPath)
+
+        let desktopValue = explorerSection?.getValue(forKey: "Desktop") ?? ""
+        let isEnabled = !desktopValue.isEmpty
+        let resolution = desktopsSection?.getValue(forKey: "Default") ?? "1920x1080"
+        let dpiStr = fontsSection?.getValue(forKey: "LogPixels") ?? "96"
+        let dpi = UInt32(dpiStr) ?? 96
+
+        return ResolutionState(
+            isVirtualDesktopEnabled: isEnabled,
+            resolution: resolution,
+            dpi: dpi
+        )
+    }
+
+    // MARK: - Write
+
+    func applyResolution(_ resolution: String?, dpi: UInt32? = nil) throws {
+        try registryFile.load()
+
+        let explorerSection = registryFile.section(forPath: explorerPath)
+        let desktopsSection = registryFile.section(forPath: desktopsPath)
+
+        if let resolution = resolution {
+            // Enable virtual desktop with given resolution
+            explorerSection?.addOrSetValue(forKey: "Desktop", stringValue: "Default")
+            desktopsSection?.addOrSetValue(forKey: "Default", stringValue: resolution)
+            console.log("Setting resolution to \(resolution)")
+        } else {
+            // Disable virtual desktop
+            explorerSection?.addOrSetValue(forKey: "Desktop", stringValue: "")
+            console.log("Disabling virtual desktop")
+        }
+
+        if let dpi = dpi {
+            let fontsSection = registryFile.section(forPath: fontsPath)
+            fontsSection?.setDword(forKey: "LogPixels", value: dpi)
+            console.log("Setting DPI to \(dpi)")
+        }
+
+        try registryFile.save()
+    }
+
+    func disableVirtualDesktop() throws {
+        try applyResolution(nil)
+    }
+
+    // MARK: - Display detection
+
+    static func detectDisplayProfiles() -> [ResolutionProfile] {
+        let screens = NSScreen.screens
+        guard !screens.isEmpty else {
+            return [ResolutionProfile(name: "Default", resolution: "1920x1080")]
+        }
+        var profiles: [ResolutionProfile] = []
+        var seen = Set<String>()
+        for screen in screens {
+            let backing = screen.convertRectToBacking(screen.frame)
+            let w = Int(backing.width)
+            let h = Int(backing.height)
+            let res = "\(w)x\(h)"
+            guard !seen.contains(res) else { continue }
+            seen.insert(res)
+            let name = screen == screens.first ? "Built-in" : "External"
+            profiles.append(ResolutionProfile(name: name, resolution: res))
+        }
+        return profiles
+    }
+}

--- a/Procyon/Util/WineRegistry.swift
+++ b/Procyon/Util/WineRegistry.swift
@@ -1,0 +1,258 @@
+//
+//  WineRegistry.swift
+//  Procyon
+//
+//  Wine .reg file parser and editor with backup support.
+//
+
+import Foundation
+
+enum WineRegValueType {
+    case string(String)
+    case dword(UInt32)
+    case hex(Data)
+    case expandString(String)
+    case defaultValue(String)
+}
+
+struct WineRegValue {
+    var type: WineRegValueType
+    var rawLine: String // preserves original formatting for untouched values
+}
+
+class WineRegSection {
+    var header: String       // e.g. "[Software\\\\Wine\\\\Explorer]"
+    var timestamp: String?   // e.g. "1772562888"
+    var timeLine: String?    // e.g. "#time=1dcab3c6a58a0ea"
+    var values: [(key: String, value: WineRegValue)] = []
+    var trailingLines: [String] = [] // blank lines or comments after last value
+
+    init(header: String, timestamp: String? = nil, timeLine: String? = nil) {
+        self.header = header
+        self.timestamp = timestamp
+        self.timeLine = timeLine
+    }
+
+    var path: String {
+        // Strip brackets and timestamp: "[Software\\\\Wine\\\\Explorer] 12345" -> "Software\\\\Wine\\\\Explorer"
+        let stripped = header.trimmingCharacters(in: .whitespaces)
+        guard stripped.hasPrefix("[") else { return stripped }
+        let inner = stripped.dropFirst()
+        guard let closeBracket = inner.firstIndex(of: "]") else { return String(inner) }
+        return String(inner[inner.startIndex..<closeBracket])
+    }
+
+    func getValue(forKey key: String) -> String? {
+        guard let entry = values.first(where: { $0.key == key }) else { return nil }
+        switch entry.value.type {
+        case .string(let v): return v
+        case .dword(let v): return String(v)
+        case .expandString(let v): return v
+        case .defaultValue(let v): return v
+        case .hex: return nil
+        }
+    }
+
+    func setValue(forKey key: String, stringValue: String) {
+        guard let index = values.firstIndex(where: { $0.key == key }) else { return }
+        values[index].value.type = .string(stringValue)
+        values[index].value.rawLine = "\"\(key)\"=\"\(stringValue)\""
+    }
+
+    func setDword(forKey key: String, value: UInt32) {
+        guard let index = values.firstIndex(where: { $0.key == key }) else { return }
+        values[index].value.type = .dword(value)
+        values[index].value.rawLine = "\"\(key)\"=dword:\(String(format: "%08x", value))"
+    }
+
+    func addOrSetValue(forKey key: String, stringValue: String) {
+        if let index = values.firstIndex(where: { $0.key == key }) {
+            values[index].value.type = .string(stringValue)
+            values[index].value.rawLine = "\"\(key)\"=\"\(stringValue)\""
+        } else {
+            let val = WineRegValue(type: .string(stringValue), rawLine: "\"\(key)\"=\"\(stringValue)\"")
+            values.append((key: key, value: val))
+        }
+    }
+}
+
+class WineRegistryFile {
+    var headerLines: [String] = [] // "WINE REGISTRY Version 2", comments, #arch line
+    var sections: [WineRegSection] = []
+    let fileURL: URL
+
+    init(fileURL: URL) {
+        self.fileURL = fileURL
+    }
+
+    // MARK: - Backup
+
+    /// Creates a backup before writing.
+    /// First call creates ".orig" backup. Subsequent calls create ".procyon-backup".
+    func createBackup() throws {
+        let f = FileManager.default
+        let origPath = fileURL.appendingPathExtension("orig")
+        let procyonPath = fileURL.appendingPathExtension("procyon-backup")
+
+        if !f.fileExists(atPath: origPath.path(percentEncoded: false)) {
+            try f.copyItem(at: fileURL, to: origPath)
+            console.log("Created orig backup at \(origPath.lastPathComponent)")
+        } else {
+            // orig already exists, create/overwrite procyon backup
+            if f.fileExists(atPath: procyonPath.path(percentEncoded: false)) {
+                try f.removeItem(at: procyonPath)
+            }
+            try f.copyItem(at: fileURL, to: procyonPath)
+            console.log("Created procyon backup at \(procyonPath.lastPathComponent)")
+        }
+    }
+
+    // MARK: - Parse
+
+    func load() throws {
+        let content = try String(contentsOf: fileURL, encoding: .utf8)
+        var lines: [String] = []
+        content.enumerateLines { line, _ in lines.append(line) }
+
+        headerLines = []
+        sections = []
+
+        var currentSection: WineRegSection? = nil
+        var inHeader = true
+
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            // Detect section header: [Path\\Key] optional_timestamp
+            if trimmed.hasPrefix("[") && !trimmed.hasPrefix("#") {
+                // Finish previous section
+                if let sec = currentSection {
+                    sections.append(sec)
+                }
+                inHeader = false
+
+                // Parse timestamp from header line
+                var timestamp: String? = nil
+                if let closeBracket = trimmed.firstIndex(of: "]") {
+                    let afterBracket = trimmed[trimmed.index(after: closeBracket)...].trimmingCharacters(in: .whitespaces)
+                    if !afterBracket.isEmpty {
+                        timestamp = afterBracket
+                    }
+                }
+
+                currentSection = WineRegSection(header: trimmed, timestamp: timestamp)
+                continue
+            }
+
+            if inHeader {
+                headerLines.append(line)
+                continue
+            }
+
+            guard let section = currentSection else {
+                headerLines.append(line)
+                continue
+            }
+
+            // #time= line
+            if trimmed.hasPrefix("#time=") {
+                section.timeLine = trimmed
+                continue
+            }
+
+            // Empty or comment line
+            if trimmed.isEmpty || trimmed.hasPrefix(";;") || trimmed.hasPrefix("#") {
+                section.trailingLines.append(line)
+                continue
+            }
+
+            // Parse key=value
+            if let parsed = parseRegValue(line: trimmed) {
+                // Move any accumulated trailing lines back (they were between values)
+                section.values.append(parsed)
+            } else {
+                section.trailingLines.append(line)
+            }
+        }
+
+        // Don't forget last section
+        if let sec = currentSection {
+            sections.append(sec)
+        }
+    }
+
+    private func parseRegValue(line: String) -> (key: String, value: WineRegValue)? {
+        // Default value: @="something"
+        if line.hasPrefix("@=") {
+            let val = String(line.dropFirst(2))
+            let unquoted = unquote(val)
+            return (key: "@", value: WineRegValue(type: .defaultValue(unquoted), rawLine: line))
+        }
+
+        // "Key"=value
+        guard line.hasPrefix("\"") else { return nil }
+        let parts = line.split(separator: "=", maxSplits: 1)
+        guard parts.count == 2 else { return nil }
+
+        let key = unquote(String(parts[0]))
+        let rawValue = String(parts[1]).trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if rawValue.hasPrefix("dword:") {
+            let hexStr = String(rawValue.dropFirst(6))
+            let intVal = UInt32(hexStr, radix: 16) ?? 0
+            return (key: key, value: WineRegValue(type: .dword(intVal), rawLine: line))
+        } else if rawValue.hasPrefix("hex:") {
+            return (key: key, value: WineRegValue(type: .hex(Data()), rawLine: line))
+        } else if rawValue.hasPrefix("str(2):") {
+            let inner = unquote(String(rawValue.dropFirst(7)))
+            return (key: key, value: WineRegValue(type: .expandString(inner), rawLine: line))
+        } else {
+            let unquoted = unquote(rawValue)
+            return (key: key, value: WineRegValue(type: .string(unquoted), rawLine: line))
+        }
+    }
+
+    private func unquote(_ s: String) -> String {
+        var str = s.trimmingCharacters(in: .whitespacesAndNewlines)
+        if str.hasPrefix("\"") && str.hasSuffix("\"") && str.count >= 2 {
+            str = String(str.dropFirst().dropLast())
+        }
+        return str
+    }
+
+    // MARK: - Lookup
+
+    func section(forPath path: String) -> WineRegSection? {
+        return sections.first { $0.path == path }
+    }
+
+    // MARK: - Write
+
+    func save() throws {
+        try createBackup()
+
+        var output = ""
+
+        // Header
+        for line in headerLines {
+            output += line + "\n"
+        }
+
+        // Sections
+        for section in sections {
+            output += section.header + "\n"
+            if let timeLine = section.timeLine {
+                output += timeLine + "\n"
+            }
+            for entry in section.values {
+                output += entry.value.rawLine + "\n"
+            }
+            for trailing in section.trailingLines {
+                output += trailing + "\n"
+            }
+        }
+
+        try output.write(to: fileURL, atomically: true, encoding: .utf8)
+        console.log("Registry file saved to \(fileURL.lastPathComponent)")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds Wine registry (.reg) file parser with backup support (`.orig` and `.procyon-backup`)
- Per-game virtual desktop resolution configuration based on CXRes logic
- Resolution applied to bottle's `user.reg` at game launch time (only if changed)
- Display detection for quick resolution presets

## New Files
- `Procyon/Util/WineRegistry.swift` — Generic Wine `.reg` file parser (read/edit/write with format preservation)
- `Procyon/Util/Resolution.swift` — `BottleResolutionManager` for resolution configuration

## Modified Files
- `Procyon/Types.swift` — Added `virtualDesktopEnabled` and `virtualDesktopResolution` to game options
- `Procyon/Components/GameOptionsView.swift` — Resolution UI section for non-native games
- `Procyon/Util/Launcher.swift` — Applies per-game resolution before launch
- `.gitignore` — Added `.DS_Store` and `xcuserdata/`

## Test plan
- [ ] Open game options for a Windows game and verify Resolution section appears
- [ ] Toggle virtual desktop and set resolution, save settings
- [ ] Launch game and verify `user.reg` is updated with correct resolution
- [ ] Verify `.orig` backup is created on first write
- [ ] Verify `.procyon-backup` is created on subsequent writes
- [ ] Confirm native games don't show the resolution section
- [ ] Launch multiple games with different resolution settings and verify each applies correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)