### PR TITLE
Update config parsing and steam wine path variable use

### DIFF
--- a/Procyon/Util/ConfigParser.swift
+++ b/Procyon/Util/ConfigParser.swift
@@ -1,0 +1,48 @@
+//
+//  INIConfigParser.swift
+//  Procyon
+//
+//  Created by Coderdifference on 30/5/2026.
+//
+import Foundation
+
+/// Returns all key=value pairs within the specified section of an INI-style config file at the given file path.
+/// - Parameters:
+///   - filePath: The path to the config file.
+///   - section: The section header name to search for (case sensitive).
+/// - Returns: A dictionary of key/value pairs found in the section, or an empty dictionary if the section is not found or the file cannot be read.
+public func getConfigSection(filePath: String, section: String) -> [String: String] {
+    guard let content = try? String(contentsOfFile: filePath, encoding: .utf8) else {
+        return [:]
+    }
+    var result = [String: String]()
+    var inSection = false
+    for line in content.split(separator: "\n") {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("[") && trimmed.hasSuffix("]") {
+            inSection = (String(trimmed.dropFirst().dropLast()) == section)
+            continue
+        }
+        if inSection && !trimmed.isEmpty && !trimmed.hasPrefix(";") {
+            let parts = trimmed.split(separator: "=", maxSplits: 1)
+            if parts.count == 2 {
+                let rawKey = parts[0].trimmingCharacters(in: .whitespaces)
+                let rawValue = parts[1].trimmingCharacters(in: .whitespaces)
+                let key = rawKey.trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+                let value = rawValue.trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+                result[key] = value
+            }
+        }
+    }
+    return result
+}
+
+/// Returns all key=value pairs within the specified section of an INI-style config file at the given URL.
+/// - Parameters:
+///   - fileURL: The URL of the config file.
+///   - section: The section header name to search for (case sensitive).
+/// - Returns: A dictionary of key/value pairs found in the section, or an empty dictionary if the section is not found or the file cannot be read.
+public func getConfigSection(fileURL: URL, section: String) -> [String: String] {
+    return getConfigSection(filePath: fileURL.path, section: section)
+}
+

--- a/Procyon/Util/Crossover.swift
+++ b/Procyon/Util/Crossover.swift
@@ -30,20 +30,25 @@ func getCXPatcherBottlesURL(appDir: URL)  throws -> URL {
     let base = f.homeDirectoryForCurrentUser
     
     let confPath: URL = appDir.appendingPathComponent("/Contents/SharedSupport/CrossOver/etc/CrossOver.conf")
-    let confFile = try String(contentsOf: confPath, encoding: .utf8)
-    for line in confFile.components(separatedBy: "\n") {
-        let (key, value) = parseCXEnvVarString(String(line))
-        if key == "CX_BOTTLE_PATH" {
-            if(value.contains("/Users/${USER}/")) {
-                let path = value.split(separator: "/").last?.description ?? ""
-                return base.appendingPathComponent(path, isDirectory: true)
-            } else {
-                return URL(filePath: value)
-            }
+    console.log("Loading CrossOver configurationf from \(confPath.path) ...")
+    let envSection = getConfigSection(fileURL: confPath, section: "EnvironmentVariables")
+    console.log("Finding CX_BOTTLE_PATH in configuration ...")
+    let cxBottlePath = envSection["CX_BOTTLE_PATH"]
+    if let cxBottlePath {
+        console.log("Found CX_BOTTLE_PATH in configuration: \(cxBottlePath)")
+
+        if cxBottlePath.hasPrefix("/Users/${USER}/") {
+            console.log("Found user based path, transforming to local user path ...")
+            let components = cxBottlePath.split(separator: "/").dropFirst(2) // ["Users", "${USER}", "..."]
+            let path = components.joined(separator: "/")
+            return base.appendingPathComponent(path, isDirectory: true)
+        } else {
+            return URL(filePath: cxBottlePath)
         }
     }
+    
     // fallback if it doesn't find it in the config file (just in case)
-    console.warn("Couldn't find CXPatcher bottles configuration")
+    console.warn("Couldn't find CXPatcher bottles configuration: " + confPath.absoluteString)
     let bottlePathForCXP: URL = PROCYON_SUPPORT_FOLDER_URL.appendingPathComponent(DEFAULT_CXP_BOTTLES_FOLDER, isDirectory: true)
     return bottlePathForCXP
 }

--- a/Procyon/Util/Misc.swift
+++ b/Procyon/Util/Misc.swift
@@ -156,7 +156,12 @@ func getSteamUserDataFallback (usingBottlePath: URL) -> UserInfo? {
     if let key = users?.keys.first {
         let user = users![key] as? [String: Any]
         let personaName = user?["PersonaName"] as? String ?? ""
-        let avatar = usingBottlePath.appendingPathComponent("/drive_c/Program Files (x86)/Steam/config/avatarcache/").appendingPathComponent(key).appendingPathExtension("png").absoluteString
+        let avatar = usingBottlePath
+            .appendingPathComponent(DEFAULT_STEAM_WINE_PATH)
+            .appendingPathComponent("avatarcache")
+            .appendingPathComponent(key)
+            .appendingPathExtension("png")
+            .absoluteString
         let fallbackProfileData = UserInfo(
             steamID: "",
             communityVisibilityState: 0,


### PR DESCRIPTION
Added ConfigParser to cleanly process CrossOver config file. 
Updated logic for CX_BOTTLE_PATH evaluation 
Switched magic string to use DEFAULT_STEAM_WINE_PATH (no functional effect)