### PR TITLE
Add Steam search for custom games

### DIFF
--- a/Procyon/Components/CustomGameView.swift
+++ b/Procyon/Components/CustomGameView.swift
@@ -12,6 +12,11 @@ struct CustomGameView: View {
     @State private var text: String = ""
     @State private var game: Game = .emptyGame
     @State private var id: String = ""
+    @State private var showDetails = false
+    @State private var isSearchingSteam = false
+    @State private var steamSearchResults: [SteamStoreSearchItem] = []
+    @State private var steamSearchTask: Task<Void, Never>?
+    @State private var skipNextSteamSearch = false
     @EnvironmentObject var libraryPageGlobals: LibraryPageGlobals
     @Binding var isPresented: Bool
     
@@ -32,6 +37,9 @@ struct CustomGameView: View {
                             Text(game.name).tag(game.id)
                         }
                     }.onChange(of: id) {
+                        steamSearchTask?.cancel()
+                        skipNextSteamSearch = true
+                        steamSearchResults = []
                         if id != "" {
                             if let currentGame = libraryPageGlobals.getCustomAddedGame(id: id) {
                                 game = currentGame
@@ -42,7 +50,23 @@ struct CustomGameView: View {
                     }
                     VStack(alignment: .leading, spacing: 6) {
                         Text("Game Title")
-                        TextField("Game Title", text: $game.name)
+                        HStack {
+                            TextField("Game Title", text: $game.name)
+                                .onChange(of: game.name) { _, _ in scheduleSteamSearch() }
+                            if isSearchingSteam { ProgressView().controlSize(.small) }
+                        }
+                        if !steamSearchResults.isEmpty {
+                            VStack(alignment: .leading, spacing: 2) {
+                                ForEach(steamSearchResults.prefix(8)) { result in
+                                    Button(result.name) { applySteamResult(result) }
+                                        .buttonStyle(.plain)
+                                }
+                            }
+                            .padding(8)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(.accent.opacity(0.15))
+                            .cornerRadius(8)
+                        }
                     }
                     VStack(alignment: .leading, spacing: 6) {
                         Text("Header Image URL")
@@ -88,6 +112,13 @@ struct CustomGameView: View {
                     }
                 }
             }
+            Button {
+                showDetails.toggle()
+            } label: {
+                Label("Details", systemImage: showDetails ? "chevron.down" : "chevron.right")
+            }
+            .buttonStyle(.plain)
+            if showDetails {
             // Descriptions
             HStack(alignment: .top, spacing: 20) {
                 VStack(alignment: .leading, spacing: 6) {
@@ -183,6 +214,7 @@ struct CustomGameView: View {
                     )
                 }
             }
+            }
             Group {
                 if id != "" {
                     ProminentButton("Update Game", systemImage: "arrow.2.circlepath") {
@@ -201,6 +233,41 @@ struct CustomGameView: View {
         }
         .padding(.vertical)
         .frame(width: 700)
+    }
+    
+    private func scheduleSteamSearch() {
+        if skipNextSteamSearch { skipNextSteamSearch = false; return }
+        steamSearchTask?.cancel()
+        let query = game.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard query.count >= 2, query != "Game Name here" else {
+            steamSearchResults = []; isSearchingSteam = false; return
+        }
+        steamSearchTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 400_000_000)
+            guard !Task.isCancelled else { return }
+            isSearchingSteam = true
+            defer { isSearchingSteam = false }
+            steamSearchResults = (try? await api.searchStore(term: query)) ?? []
+        }
+    }
+    
+    private func applySteamResult(_ result: SteamStoreSearchItem) {
+        steamSearchTask?.cancel()
+        isSearchingSteam = true
+        Task { @MainActor in
+            defer { isSearchingSteam = false }
+            guard let steamGame = try? await api.fetchGameInfo(appID: result.appid) else { return }
+            let exe = game.appExeURL
+            let names = game.appNames
+            let native = game.isNative
+            let nextID = (game.id.isEmpty || game.id == "example")
+                ? (exe?.path(percentEncoded: false) ?? result.appid)
+                : game.id
+            skipNextSteamSearch = true
+            game = Game(from: steamGame, id: nextID, isNative: native, downloadProgress: 100, isInstalled: true, appNames: names, isCustom: true)
+            game.appExeURL = exe
+            steamSearchResults = []
+        }
     }
 }
 

--- a/Procyon/Components/GameDetailView.swift
+++ b/Procyon/Components/GameDetailView.swift
@@ -43,8 +43,9 @@ struct GameDetailView: View {
                     } else {
                         KFImage(URL(string: game!.headerImage))
                             .placeholder {
-                                ProgressView()
+                                if !game!.headerImage.isEmpty { ProgressView() }
                             }
+                            .onFailureView { Color.clear }
                             .resizable()
                             .scaledToFit()
                     }

--- a/Procyon/Components/GameThumbnail.swift
+++ b/Procyon/Components/GameThumbnail.swift
@@ -38,8 +38,9 @@ struct GameThumbnail: View {
                 ZStack(alignment: .topTrailing){
                     KFImage(URL(string: item.headerImage))
                         .placeholder {
-                            ProgressView()
+                            if !item.headerImage.isEmpty { ProgressView() }
                         }
+                        .onFailureView { Color.clear }
                         .resizable()
                         .aspectRatio(2.15, contentMode: .fit)
                         .frame(maxWidth:.infinity, maxHeight: .infinity, alignment: .top)

--- a/Procyon/LibraryPage.swift
+++ b/Procyon/LibraryPage.swift
@@ -29,11 +29,10 @@ struct LibraryPage: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .ignoresSafeArea()
                     .background {
-                        if (libraryPageGlobals.selectedGame?.headerImage != nil){
-                            KFImage(URL(string: libraryPageGlobals.selectedGame!.headerImage))
-                                .placeholder {
-                                    ProgressView()
-                                }
+                        if let headerImage = libraryPageGlobals.selectedGame?.headerImage,
+                           !headerImage.isEmpty,
+                           let url = URL(string: headerImage) {
+                            KFImage(url)
                                 .resizable()
                                 .scaledToFill()
                                 .blur(radius: 10)

--- a/Procyon/Types.swift
+++ b/Procyon/Types.swift
@@ -228,6 +228,7 @@ struct Game: Identifiable, Codable {
         self.downloadProgress = downloadProgress
         self.isInstalled = isInstalled
         self.appNames = appNames
+        self.isCustom = isCustom
         
         // SteamGame property
         self.type = from.type

--- a/Procyon/Util/API.swift
+++ b/Procyon/Util/API.swift
@@ -21,6 +21,12 @@ struct SteamGameResponse: Codable, Sendable {
     let data: [SteamGame]
 }
 
+struct SteamStoreSearchItem: Codable, Identifiable, Sendable {
+    let appid: String
+    let name: String
+    var id: String { appid }
+}
+
 struct SteamOwnedGamesResponse: Codable, Sendable {
     let response: SteamOwnedGames
 }
@@ -192,6 +198,27 @@ final class SteamAPI {
         self.cacheOwnedGamesIDs.removeAll()
         console.warn("IDs Cache deleted")
     }
+    func searchStore(term: String) async throws -> [SteamStoreSearchItem] {
+        let trimmed = term.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+        var allowed = CharacterSet.urlPathAllowed
+        allowed.remove(charactersIn: "/")
+        guard let encoded = trimmed.addingPercentEncoding(withAllowedCharacters: allowed) else {
+            throw APIError.badURL
+        }
+        let urlString = "https://steamcommunity.com/actions/SearchApps/\(encoded)"
+        let headers: HTTPHeaders = [
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15",
+            "Accept": "application/json"
+        ]
+        let data = try await AF.request(urlString, method: .get, headers: headers)
+            .validate(statusCode: 200..<300)
+            .serializingData()
+            .value
+        guard !data.isEmpty else { return [] }
+        return try JSONDecoder().decode([SteamStoreSearchItem].self, from: data)
+    }
+    
     func fetchGameInfo(appID: String) async throws -> SteamGame? {
         if self.cacheBlacklist.contains(appID) {
             console.log("skipping \(appID) as it's blacklisted")


### PR DESCRIPTION
## Summary
- Debounced Steam store search while typing a custom game title, with one-click apply of store details (game stays custom)
- Collapse description/details fields by default in the custom game editor
- Skip endless image spinners when header art is missing or fails to load